### PR TITLE
show all users on leaderboard sorted by winRatio descending

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Add additional notes about how to deploy this on a live system
 * **Sam Evers** - [sam123evers](https://github.com/sam123evers)
 * **Taylor Lang** - [TayLang](https://github.com/TayLang)
 * **Sean Wyse** - [wysesean](https://github.com/wysesean)
+* **Amanda Wolgamott** - [awolgamott](https://github.com/awolgamott)
 
 
 

--- a/dist/assets/js/app.js
+++ b/dist/assets/js/app.js
@@ -1,0 +1,1 @@
+console.error("SyntaxError: /Users/akirkpatrick100/Documents/TIY/assignments/IronPong/src/scripts/views/leaderboardPage.js: Unexpected token, expected , (39:2) while parsing file: /Users/akirkpatrick100/Documents/TIY/assignments/IronPong/src/scripts/views/leaderboardPage.js");

--- a/src/scripts/actions.js
+++ b/src/scripts/actions.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import User from './models/userModel.js'
-
+import STORE from './store'
 const ACTIONS = {
 
 	registerUser: function(formData) {

--- a/src/scripts/views/leaderboardPage.js
+++ b/src/scripts/views/leaderboardPage.js
@@ -10,6 +10,9 @@ var LeaderboardPage = React.createClass({
 			this.setState(STORE.data)
 		})
 	},
+	componentWillUnmount: function() {
+		STORE.off('dataUpdated')
+	},
 	getInitialState: function() {
 		return STORE.data
 	},
@@ -27,8 +30,38 @@ var LeaderboardPage = React.createClass({
 
 var LeaderboardDisplay = React.createClass({
 	render: function() {
+		var users = this.props.userColl.models
+
+		users = users.sort( function(a, b) {
+			return b.get("winRatio") - a.get("winRatio")
+		}
+		
 		return(
-			
+			<div>
+				<table>
+					<thead>
+						<tr>
+							<th>Name</th>
+							<th>Wins</th>
+							<th>Losses</th>
+							<th>Winning Streak</th>
+							<th>Winning Percentage</th>
+						</tr>
+					</thead>
+					<tbody>
+						{users.map( (user) => {
+							return <tr key={user.get("_id")}>
+								<td>{user.get("nickName")}</td>
+								<td>{user.get("wins")}</td>
+								<td>{user.get("losses")}</td>
+								<td>{user.get("winStreak")}</td>
+								<td>{user.get("winRatio")}</td>
+							</tr>
+						})}
+					</tbody>
+				</table>
+
+			</div>
 		)
 	}
 })


### PR DESCRIPTION
Looping over all the users in the user collection and then sorting them with winRatio

All values we use in the leaderboard (nickName, wins, losses, winStreak, winRatio) are stored in the user table.

What it looks like (will submit new pull request once styling guide and can test with sample data)
<img width="870" alt="screen shot 2017-03-31 at 8 13 13 pm" src="https://cloud.githubusercontent.com/assets/25491312/24573807/8119b788-164e-11e7-8066-72117d0040f9.png">


Old IronPong Version
<img width="867" alt="screen shot 2017-03-31 at 8 12 25 pm" src="https://cloud.githubusercontent.com/assets/25491312/24573802/6fb064ce-164e-11e7-8684-cb8be5d3cf3c.png">
