### PR TITLE
changed leaderboard to only display accounts that have been claimed

### DIFF
--- a/src/scripts/views/leaderboardPage.js
+++ b/src/scripts/views/leaderboardPage.js
@@ -22,7 +22,7 @@ var LeaderboardPage = React.createClass({
 			<div className = 'leaderboard-page-wrapper'>
 				<Header />
 				<NavBar />
-				<LeaderboardDisplay userColl={this.state.userCollection} />
+				<LeaderboardDisplay userColl={this.state.userCollection.where({claimed:true})} />
 			</div>
 		)
 


### PR DESCRIPTION
Leaderboard no longer displays unclaimed accounts,  just added a .where({claimed:true}) to the collection in the leaderboard